### PR TITLE
Hide pagination when no data

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,6 +24,7 @@ function App () {
     minStars: '',
     maxStars: ''
   })
+  const [hidePagination, setHidePagination] = useState(true)
 
   const { theme } = useContext(ThemeContext)
 
@@ -51,6 +52,7 @@ function App () {
         setPageNumber={setPageNumber}
         pageNumber={pageNumber}
         maxPageNumber={maxPageNumber}
+        hidePagination={hidePagination}
       />
 
       <CardSet
@@ -63,11 +65,13 @@ function App () {
         reducedState={reducedState}
         setReducedState={setReducedState}
         inputSearch={inputSearch}
+        setHidePagination={setHidePagination}
       />
       <Navigation
         setPageNumber={setPageNumber}
         pageNumber={pageNumber}
         maxPageNumber={maxPageNumber}
+        hidePagination={hidePagination}
       />
     </div>
   )

--- a/src/components/CardSet.js
+++ b/src/components/CardSet.js
@@ -20,6 +20,11 @@ const CardSet = props => {
   const { theme } = useContext(ThemeContext)
   const [forksQuery, setForksQuery] = useState('')
   const [starsQuery, setStarsQuery] = useState('')
+  const [CardSetLength, setCardSetLength] = useState(0)
+
+  useEffect(() => {
+    setCardSetLength(document.getElementById("header").getBoundingClientRect().height + document.getElementById("filter-container").getBoundingClientRect().height + 'px')
+  }, [])
 
   let url = `https://api.github.com/search/repositories?q=good-first-issues:>0+language:${
     props.language
@@ -108,10 +113,14 @@ const CardSet = props => {
           setRepositories(response.data.items)
           setWasRejected(false)
           setIsLoading(false)
+          response.data.items.length ? props.setHidePagination(false) : props.setHidePagination(true)
         },
         rejection => {
-          if (rejection.response.status === 403) setWasRejected(true)
-          //console.log(rejection.response.data)
+          if (rejection.response.status === 403) {
+            setWasRejected(true)
+            props.setHidePagination(true)
+          }
+          // console.log(rejection.response.data)
         }
       )
       .catch(errors => {
@@ -123,7 +132,7 @@ const CardSet = props => {
   }, [props, url])
 
   return (
-    <div style={{ backgroundColor: theme.bg, color: theme.color }}>
+    <div style={{ backgroundColor: theme.bg, color: theme.color, minHeight: `calc(100vh - ${CardSetLength})` }}>
       {isLoading ? (
         <div className='loader-container'>
           <div className='loader'></div>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -35,7 +35,7 @@ const Header = (props) => {
 	};
 
 	return (
-			<Navbar bg={theme.mode} variant={theme.mode} expand="lg">
+			<Navbar bg={theme.mode} variant={theme.mode} expand="lg" id="header">
 				<Container fluid>
 					<Navbar.Brand href="#home">Find Me Issues</Navbar.Brand>
 					{theme.mode === "light" ? (

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -80,7 +80,7 @@ const Navigation = (props) => {
   }
 
   return (
-    <div style={{ backgroundColor: theme.bg, color: theme.color}}>
+    <div style={{ backgroundColor: theme.bg, color: theme.color, display: props.hidePagination ? 'none' : 'block'}}>
       <Pagination className={classes.navBar}>
         <Pagination.First
           onClick={() => {

--- a/src/components/RepoFilters.js
+++ b/src/components/RepoFilters.js
@@ -57,6 +57,7 @@ const RepoFilters = ({ reducedState, setReducedState }) => {
       style={{
         marginTop: '20px'
       }}
+      id="filter-container"
     >
       <DropdownToggle
         aria-expanded={isButtonCollapseOpen}


### PR DESCRIPTION
## Changes
1. Hide pagination when no issues to show or if rate limit exceeded
- added state hook to control visibility of pagination
2. Add min-height to cards container
- this is to cover up the white space that was otherwise visible

![image](https://user-images.githubusercontent.com/106474125/219880335-e1dd4419-06e3-4065-a2db-abe1f13c151b.png)

(I am new to contributing to open source)