### PR TITLE
Issue #105: Fixed text color while hovering buttons on SingleCard

### DIFF
--- a/src/components/SingleCard.js
+++ b/src/components/SingleCard.js
@@ -98,6 +98,9 @@ const SingleCard = (props) => {
 									<Button
 										variant="outline-info"
 										onClick={() => setOpen(!openIssues)}
+										style={{
+											'-webkit-text-stroke': '0.4px black'
+										}}
 									>
 										Go To Issues
 									</Button>


### PR DESCRIPTION
This was setting an override for the button text:

- `WebkitTextStroke: "0.4px white",`

Left this code for the displaying the button as is. Added to the style of the button:

- `style={{'-webkit-text-stroke': '0.4px black'}}`