### PR TITLE
Fix button hover text color not changing to black 

### DIFF
--- a/src/components/SingleCard.js
+++ b/src/components/SingleCard.js
@@ -41,7 +41,7 @@ const SingleCard = (props) => {
 				width: "100%",
 				margin: "10px",
 				padding: "10px",
-				WebkitTextStroke: "0.4px white",
+			
 				height: "100%",
 			}}
 		>


### PR DESCRIPTION


- Update CSS styles to ensure text color changes to black on hover
- Addresses issue #105
- Improves button consistency across the UI

-Issue was : When we hover over some of the buttons, the text color does not change to black! issue #105 fixed this bug
