### PR TITLE
Fixed Header styles

### DIFF
--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -28,6 +28,9 @@
   border-width: 0;
   border-radius: 0;
 }
+.header__search--desktop:focus{
+  box-shadow: none;
+}
 
 /* --------------- INPUTGROUP ICONS --------------- */
 .header__divider {
@@ -63,6 +66,9 @@
   border-color: white;
   border-width: 0;
   border-radius: 0rem 0.25rem 0.25rem 0rem;
+}
+.header__dropdown--desktop:focus{
+ box-shadow: none;
 }
 .header_dropdown{
   height: 300px;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -81,7 +81,7 @@ const Header = ({ language, setLanguage, setInputSearch }) => {
 
         <InputGroup.Prepend>
           <InputGroup.Text className="inputgroup_icon--mid">
-            <Container className="noBuff">
+            <Container className="noBuff px-2">
               <i className="fa fa-code" aria-hidden="true" />
             </Container>
           </InputGroup.Text>


### PR DESCRIPTION
This pull request includes the following changes:

Removed Box Shadow on Focus:

Added a CSS rule to remove the box shadow when an element is focused.

CSS Property Added:  Header.css

.header__search--desktop:focus{
  box-shadow: none;
}
Reason: This change is intended to streamline the focus state appearance and avoid any unwanted visual effects when the element is focused.

Added Padding with Bootstrap Class:

Added the Bootstrap class px-2 to provide padding and ensure consistent spacing.
Bootstrap Class Applied: Header.js
 <Container className="noBuff px-2">
              <i className="fa fa-code" aria-hidden="true" />
            </Container>
Reason: This adjustment is made to ensure that there is adequate spacing around the content, enhancing the overall layout and readability.

Please review these changes and let me know if there are any suggestions or modifications needed.